### PR TITLE
Add "sys:node-uuid" to the list of exported properties

### DIFF
--- a/alfresco-bulk-export/src/main/java/org/alfresco/extensions/bulkexport/dao/AlfrescoExportDaoImpl.java
+++ b/alfresco-bulk-export/src/main/java/org/alfresco/extensions/bulkexport/dao/AlfrescoExportDaoImpl.java
@@ -93,7 +93,6 @@ public class AlfrescoExportDaoImpl implements AlfrescoExportDao
     private QName ignorePropertyQname[] = 
     { 
             ContentModel.PROP_NODE_DBID, 
-            ContentModel.PROP_NODE_UUID, 
             ContentModel.PROP_CATEGORIES,
             ContentModel.PROP_CONTENT,
             ContentModel.ASPECT_TAGGABLE,


### PR DESCRIPTION
The "sys:node-uuid" property is mandatory when you need to keep the
noderef unchanged during an import.